### PR TITLE
Raster copy bug

### DIFF
--- a/source/draw/RasterBgr.ooc
+++ b/source/draw/RasterBgr.ooc
@@ -29,13 +29,9 @@ RasterBgr: class extends RasterPacked {
 	init: func ~allocateStride (size: IntSize2D, stride: UInt) { super(size, stride) }
 	init: func ~fromByteBufferStride (buffer: ByteBuffer, size: IntSize2D, stride: UInt) { super(buffer, size, stride) }
 	init: func ~fromByteBuffer (buffer: ByteBuffer, size: IntSize2D) { this init(buffer, size, this bytesPerPixel * size width) }
-	init: func ~fromRasterImage (original: RasterImage) { super(original) }
+	init: func ~fromRasterImage (original: This) { super(original) }
 	create: func (size: IntSize2D) -> Image { This new(size) }
-	copy: func -> This {
-		result := This new(this)
-		this buffer copyTo(result buffer)
-		result
-	}
+	copy: func -> This { This new(this) }
 	apply: func ~bgr (action: Func(ColorBgr)) {
 		end := this buffer pointer as Long + this buffer size
 		rowLength := this size width * this bytesPerPixel

--- a/source/draw/RasterBgra.ooc
+++ b/source/draw/RasterBgra.ooc
@@ -29,13 +29,9 @@ RasterBgra: class extends RasterPacked {
 	init: func ~allocateStride (size: IntSize2D, stride: UInt) { super(size, stride) }
 	init: func ~fromByteBufferStride (buffer: ByteBuffer, size: IntSize2D, stride: UInt) { super(buffer, size, stride) }
 	init: func ~fromByteBuffer (buffer: ByteBuffer, size: IntSize2D) { this init(buffer, size, this bytesPerPixel * size width) }
-	init: func ~fromRasterImage (original: RasterImage) { super(original) }
+	init: func ~fromRasterImage (original: This) { super(original) }
 	create: func (size: IntSize2D) -> Image { This new(size) }
-	copy: func -> This {
-		result := This new(this)
-		this buffer copyTo(result buffer)
-		result
-	}
+	copy: func -> This { This new(this) }
 	apply: func ~bgr (action: Func(ColorBgr)) {
 		for (row in 0 .. this size height) {
 			source := this buffer pointer + row * this stride

--- a/source/draw/RasterMonochrome.ooc
+++ b/source/draw/RasterMonochrome.ooc
@@ -29,14 +29,9 @@ RasterMonochrome: class extends RasterPacked {
 	init: func ~allocateStride (size: IntSize2D, stride: UInt) { super(size, stride) }
 	init: func ~fromByteBufferStride (buffer: ByteBuffer, size: IntSize2D, stride: UInt) { super(buffer, size, stride) }
 	init: func ~fromByteBuffer (buffer: ByteBuffer, size: IntSize2D) { this init(buffer, size, this bytesPerPixel * size width) }
-	init: func ~fromRasterImage (original: RasterImage) { super(original) }
+	init: func ~fromRasterImage (original: This) { super(original) }
 	create: func (size: IntSize2D) -> Image { This new(size) }
-	copy: func -> This {
-		result := This new(this)
-		result _buffer = ByteBuffer new(this _buffer size)
-		this buffer copyTo(result buffer)
-		result
-	}
+	copy: func -> This { This new(this) }
 	apply: func ~bgr (action: Func(ColorBgr)) {
 		this apply(ColorConvert fromMonochrome(action))
 	}

--- a/source/draw/RasterPacked.ooc
+++ b/source/draw/RasterPacked.ooc
@@ -42,8 +42,9 @@ RasterPacked: abstract class extends RasterImage {
 		stride := this bytesPerPixel * size width
 		this init(ByteBuffer new(stride * size height), size, stride)
 	}
-	init: func ~fromOriginal (original: RasterImage) {
+	init: func ~fromOriginal (original: This) {
 		super(original)
+		this _buffer = original buffer copy()
 		this _stride = original stride
 	}
 	free: override func {

--- a/source/draw/RasterUv.ooc
+++ b/source/draw/RasterUv.ooc
@@ -123,7 +123,7 @@ RasterUv: class extends RasterPacked {
 		memcpy(buffer pointer, data, x * y * requiredComponents)
 		StbImage free(data)
 		// Is it neccessary to create a RasterBgr here?
-		This new(RasterBgr new(buffer, IntSize2D new(x, y)))
+		This convertFrom(RasterBgr new(buffer, IntSize2D new(x, y)))
 	}
 	save: override func (filename: String) -> Int {
 		bgr := RasterBgr new(this buffer, this size)
@@ -132,7 +132,7 @@ RasterUv: class extends RasterPacked {
 		result
 	}
 	convertFrom: static func (original: RasterImage) -> This {
-		result := This new(original)
+		result := This new(original size)
 		row := result buffer pointer
 		rowLength := result size width
 		rowEnd := row as ColorUv* + rowLength

--- a/source/draw/RasterUv.ooc
+++ b/source/draw/RasterUv.ooc
@@ -31,13 +31,9 @@ RasterUv: class extends RasterPacked {
 	init: func ~allocateStride (size: IntSize2D, stride: UInt) { super(size, stride) }
 	init: func ~fromByteBufferStride (buffer: ByteBuffer, size: IntSize2D, stride: UInt) { super(buffer, size, stride) }
 	init: func ~fromByteBuffer (buffer: ByteBuffer, size: IntSize2D) { this init(buffer, size, this bytesPerPixel * size width) }
-	init: func ~fromRasterImage (original: RasterImage) { super(original) }
+	init: func ~fromRasterImage (original: This) { super(original) }
 	create: func (size: IntSize2D) -> Image { This new(size) }
-	copy: func -> This {
-		result := This new(this)
-		this buffer copyTo(result buffer)
-		result
-	}
+	copy: func -> This { This new(this) }
 	apply: func ~bgr (action: Func(ColorBgr)) {
 		this apply(ColorConvert fromYuv(action))
 	}

--- a/source/draw/RasterYuv422Semipacked.ooc
+++ b/source/draw/RasterYuv422Semipacked.ooc
@@ -131,7 +131,7 @@ RasterYuv422Semipacked: class extends RasterPacked {
 		return result
 	}
 	save: func (filename: String) {
-		bgr := RasterBgr new(this)
+		bgr := RasterBgr convertFrom(this)
 		bgr save(filename)
 		bgr referenceCount decrease()
 	}


### PR DESCRIPTION
This should fix the problem with uninitialized `ByteBuffer`s when copying `RasterPacked` images.
